### PR TITLE
Add bors to project-stable-mir

### DIFF
--- a/repos/rust-lang/project-stable-mir.toml
+++ b/repos/rust-lang/project-stable-mir.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "project-stable-mir"
 description = "Define compiler intermediate representation usable by external tools"
-bots = ["rustbot"]
+bots = ["bors", "rustbot"]
 
 [access.teams]
 project-stable-mir = "write"


### PR DESCRIPTION
In https://github.com/rust-lang/project-stable-mir/pull/25 I realized we can't merge PRs anymore